### PR TITLE
adding sonic-pi-send-line

### DIFF
--- a/sonic-pi-mode.el
+++ b/sonic-pi-mode.el
@@ -22,6 +22,7 @@
     (define-key map (kbd "C-c M-c") 'sonic-pi-connect)
     (define-key map (kbd "C-c C-k") 'sonic-pi-send-buffer)
     (define-key map (kbd "C-c C-r") 'sonic-pi-send-region)
+    (define-key map (kbd "C-c C-w") 'sonic-pi-send-line)
     (define-key map (kbd "C-c C-q") 'sonic-pi-quit)
     (define-key map (kbd "C-c C-b") 'sonic-pi-stop-all)
     (define-key map (kbd "C-c C-c") 'sonic-pi-send-live-loop)

--- a/sonic-pi-osc.el
+++ b/sonic-pi-osc.el
@@ -72,6 +72,13 @@
   (hlt-highlight-regexp-region (region-beginning) (region-end) ".+" 'eval-sonic-pi-flash nil)
   (run-at-time flash-time nil 'hlt-unhighlight-region nil nil nil))
 
+(defun sonic-pi-send-line ()
+  "send a line to sonic via osc"
+  (interactive)
+  (sonic-pi-osc-send-text (line-beginning-position) (line-end-position))
+  (hlt-highlight-regexp-region (line-beginning-position) (line-end-position) ".+" 'eval-sonic-pi-flash nil)
+  (run-at-time flash-time nil 'hlt-unhighlight-region nil nil nil))
+
 (defun sonic-pi-send-buffer ()
   "send the current buffer to sonic via osc"
   (interactive)


### PR DESCRIPTION
Not sure if this helpful for others, but found it a bit of work to execute one-liners like `require "~/stuff"` and function calling. So I basically copied `sonic-pi-send-region` to make `sonic-pi-send-line` changing `(region-beginning)` to `(line-beginning-position)` and `(region-end)` to `(line-end-position)` and bound this to `C-c C-w` (taking inspiration from `C-w/M-w` line yanking/copying).

Not 100% on the `C-c C-w` keybinding but it doesn't seem to clash with any other modes I've got going on in sonic-pi buffers.