### PR TITLE
Correct path for sonic-pi-server-bin

### DIFF
--- a/sonic-pi.el
+++ b/sonic-pi.el
@@ -54,7 +54,7 @@
   :type 'string
   :group 'sonic-pi)
 
-(defvar sonic-pi-server-bin             "server/bin/sonic-pi-server.rb")
+(defvar sonic-pi-server-bin             "app/server/ruby/bin/sonic-pi-server.rb")
 (defvar sonic-pi-compile-extensions-bin "server/bin/compile-extensions.rb")
 (defvar sonic-pi-margin-size 1)
 


### PR DESCRIPTION
Fixes error: 'Could not find a sonic-pi server in sonic-pi-path' (see #25)